### PR TITLE
add delay method to automatically monitor "Stop" button

### DIFF
--- a/srsgui/task/task.py
+++ b/srsgui/task/task.py
@@ -364,6 +364,12 @@ class Task(thread_class):
         If it returns False, Task should stop ASAP.
         """
         return self._keep_running
+    
+    def delay(self, dt_s):  
+        if self._keep_running:
+            time.sleep(dt_s)
+        else:
+            raise InterruptedError("Aborted.")
 
     def is_task_passed(self):
         return self._task_passed

--- a/srsgui/task/task.py
+++ b/srsgui/task/task.py
@@ -279,7 +279,8 @@ class Task(thread_class):
 
     def delay(self, seconds):
         """
-        Check if the task is stopped and wait for the given seconds.
+        Check if the task is stopped and abort,
+        or wait for the given seconds.
         """
         if not self._keep_running:
             raise Task.TaskException('Task is requested to stop')


### PR DESCRIPTION
During long tasks (waiting for an instrument to settle, or a lengthy calculation) the code may enter a loop that periodically checks some status bit (e.g. instrument status, or calculation progress, etc.). 

As a replacement to calling `time.sleep(1.0)`, the user can call `self.delay(1.0)` from within the task. This checks the `_keep_running` attribute in case the user has pressed `Stop`, and will abort the loop (and the task) immediately. This simply replaces having to sprinkle the code with `self.is_running()` calls inside every loop.